### PR TITLE
S2E Core v5.0.0 リリースにともなうCIの修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   S2E_CORE_VERSION: v5.0.0
-  C2A_CORE_VERSION: 8e25f45b1ca1c6489f32ed298bbc0a4817f0422f # TODO change after merge
+  C2A_CORE_VERSION: develop
 
 jobs:
   build_s2e_win:


### PR DESCRIPTION
## 概要
S2E Core v5.0.0 リリースにともなうCIの修正

## Issue
- https://github.com/ut-issl/s2e-user-for-c2a-core/issues/20

## 詳細
- https://github.com/ut-issl/s2e-user-for-c2a-core/pull/18 の続き．C2A core側も追従したので，CIを更新する

## 検証結果
CIが通ればOK
