### PR TITLE
minimum_user_for_s2e を minimum_user にリネーム

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         shell: cmd
         run: |
           cl.exe
-          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=../s2e-core/ExtLibraries -DFLIGHT_SW_DIR=../c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }}
+          cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DEXT_LIB_DIR=../s2e-core/ExtLibraries -DFLIGHT_SW_DIR=../c2a-core -DC2A_NAME=Examples/minimum_user -D${{ matrix.use_c2a }}
           cmake --build . --clean-first
 
   build_s2e_linux:
@@ -181,5 +181,5 @@ jobs:
       - name: build
         working-directory: ./s2e-user
         run: |
-          cmake . -DEXT_LIB_DIR=../s2e-core/ExtLibraries -DFLIGHT_SW_DIR=../c2a-core -DC2A_NAME=Examples/minimum_user_for_s2e -D${{ matrix.use_c2a }} -DUSE_SCI_COM_WINGS=OFF
+          cmake . -DEXT_LIB_DIR=../s2e-core/ExtLibraries -DFLIGHT_SW_DIR=../c2a-core -DC2A_NAME=Examples/minimum_user -D${{ matrix.use_c2a }} -DUSE_SCI_COM_WINGS=OFF
           cmake --build .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # S2E User for C2A Core
 
 ## Overview
-- This repository is an example of S2E User to execute a sample of [minimum C2A](https://github.com/ut-issl/c2a-core/tree/develop/Examples/minimum_user_for_s2e) and to support an operation with WINGS (TBA).
+- This repository is an example of S2E User to execute a sample of [minimum C2A](https://github.com/ut-issl/c2a-core/tree/develop/Examples/minimum_user) and to support an operation with WINGS (TBA).
 - The CI system for c2a-core are using this repository.
 - This is also an example of SILS/HILS test for C2A development.
 
@@ -17,7 +17,7 @@
 
 
 ## 概要
-- C2A Core に含まれる [最小限のC2A サンプル](https://github.com/ut-issl/c2a-core/tree/develop/Examples/minimum_user_for_s2e) を SILS で動かし，かつ， WINGS (TBA) によって運用（コマンド操作とテレメトリ受信）できるようにするための最低限の S2E User．
+- C2A Core に含まれる [最小限のC2A サンプル](https://github.com/ut-issl/c2a-core/tree/develop/Examples/minimum_user) を SILS で動かし，かつ， WINGS (TBA) によって運用（コマンド操作とテレメトリ受信）できるようにするための最低限の S2E User．
 - C2A Core の CI にもこの S2E を使っている．
 - C2A 開発を始める際につかう SILS/HILS の雛形にもなりうる．
 


### PR DESCRIPTION
## 概要
minimum_user_for_s2e を minimum_user にリネーム

## Issue
- https://github.com/ut-issl/c2a-core/issues/361

## 詳細
issue参照

## 検証結果
test へのリンクや，検証結果へのリンク

## 補足
- [x] https://github.com/ut-issl/c2a-core/pull/362 がマージされてからCIを通し直して，マージする